### PR TITLE
git branch feature integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # nasher changelog
 
+## 0.14.0:
+
+### Enable NWNT Custom output language
+https://github.com/WilliamDraco/NWNT
+
+Based on nwn_gff from the neverwinter.nim tools, this output format utilises
+the libraries of those tools for a custom output language instead of json.
+The output language is designed to be similar to Json that has been put through
+gron. A standalone conversion tool is also available at the project page.
+
+To enable, use `nasher config gffFormat nwnt` (remember `--local` to only affect
+current package)
+
+### Change to nwn.nim lib calls for gffConvert
+
+Nasher calls neverwinter.nim as library, instead of deferring to the binaries.
+Only applies to gff format conversion, excluding .tlk
+
 ## 0.13.0: November 07, 2020
 
 ### Display an error message when a resource filename is > 16 characters \

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ document, you can replace it with the docker command. So the following are
 equivalent:
 ```console
 $ nasher <command>
-$ docker run --rm -it -v ${pwd}:/nasher nwneetools/nasher:latest <command>
+$ docker run --rm -it -v ${pwd}:/nasher nwntools/nasher:latest <command>
 ```
 
 #### Tips
@@ -823,7 +823,7 @@ $ # Special case for Docker usage. When issuing the install and launch commands,
 $ # docker requires access to the NWN documents folder, so we attach two volumes:
 $ # - the first volume assigns the nasher project folder (source files)
 $ # - the second volume assigns the NWN user directory
-$ docker run --rm -it -v ${pwd}:/nasher -v "~/Documents/Neverwinter Nights":/nasher/install nwneetoools/nasher:latest install <target> --yes
+$ docker run --rm -it -v ${pwd}:/nasher -v "~/Documents/Neverwinter Nights":/nasher/install nwntools/nasher:latest install <target> --yes
 ```
 
 ### launch

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ by passing the key/value pair as an option to the command.
     - default: ""
 - `gffFormat`: the format to use to store gff files
     - default: `json`
-    - supported: `json`
+    - supported: `json, nwnt`
 - `tlkUtil`: the path to the tlk conversion utility
     - default (Posix): `nwn_gff`
     - default (Windows): `nwn_gff.exe`

--- a/nasher.nimble
+++ b/nasher.nimble
@@ -13,3 +13,4 @@ bin           = @["nasher"]
 requires "nim >= 1.2.0"
 requires "neverwinter >= 1.4.0"
 requires "glob >= 0.9.1"
+requires "nwnt >= 1.2.1"

--- a/src/nasher.nim
+++ b/src/nasher.nim
@@ -1,5 +1,6 @@
+import os, strformat
 import nasher/[init, list, config, unpack, convert, compile, pack, install, launch]
-import nasher/utils/[cli, options, shared]
+import nasher/utils/[cli, git, options, shared]
 
 const
   NimblePkgVersion {.strdefine.} = "devel"
@@ -47,11 +48,13 @@ when isMainModule:
     var
       opts = getOptions()
       pkg = new(PackageRef)
+      branch = opts.get("branch", "none")
 
     let
       cmd = opts.get("command")
       help = opts.get("help", false)
       version = opts.get("version", false)
+      dir = opts.getOrPut("directory", getCurrentDir())
 
     if version:
       echo "nasher " & NimblePkgVersion
@@ -91,6 +94,11 @@ when isMainModule:
       let targets = pkg.getTargets(opts.get("targets"))
       for target in targets:
         opts["target"] = target.name
+        if branch == "none":
+          branch = target.branch
+        if branch.len > 0:
+          display("VCS Branch:", gitSetBranch(dir, branch))
+
         if convert(opts, pkg) and
            compile(opts, pkg) and
            pack(opts, pkg) and

--- a/src/nasher/compile.nim
+++ b/src/nasher/compile.nim
@@ -20,6 +20,7 @@ const
   Options:
     --clean            Clears the cache directory before compiling
     -f, --file:<file>  Compiles <file> only. Can be repeated.
+    --branch:<branch>  Selects git branch before operation.
 
   Global Options:
     -h, --help         Display help for nasher or one of its commands

--- a/src/nasher/convert.nim
+++ b/src/nasher/convert.nim
@@ -1,4 +1,4 @@
-import os, strtabs, strutils, strformat, sequtils, tables
+import os, strtabs, strutils, strformat, tables
 import utils/[cli, manifest, nwn, options, shared]
 
 const

--- a/src/nasher/convert.nim
+++ b/src/nasher/convert.nim
@@ -16,7 +16,8 @@ const
     the target file.
 
   Options:
-    --clean        Clears the cache directory before converting
+    --clean            Clears the cache directory before converting
+    --branch:<branch>  Selects git branch before operation.
 
   Global Options:
     -h, --help     Display help for nasher or one of its commands

--- a/src/nasher/install.nim
+++ b/src/nasher/install.nim
@@ -19,9 +19,10 @@ const
     and Mac or `~/.local/share/Neverwinter Nights` on Linux.
 
   Options:
-    --clean        Clears the cache directory before packing
-    --yes, --no    Automatically answer yes/no to prompts
-    --default      Automatically accept the default answer to prompts
+    --clean            Clears the cache directory before packing
+    --yes, --no        Automatically answer yes/no to prompts
+    --default          Automatically accept the default answer to prompts
+    --branch:<branch>  Selects git branch before operation.
 
   Global Options:
     -h, --help     Display help for nasher or one of its commands

--- a/src/nasher/launch.nim
+++ b/src/nasher/launch.nim
@@ -17,11 +17,12 @@ const
     player character in the localvault.
 
   Options:
-    --gameBin      The path to the nwmain binary file (if not the OS default)
-    --serverBin    The path to the nwserver binary file (if not the OS default)
-    --clean        Clears the cache directory before packing
-    --yes, --no    Automatically answer yes/no to prompts
-    --default      Automatically accept the default answer to prompts
+    --gameBin          The path to the nwmain binary file (if not the OS default)
+    --serverBin        The path to the nwserver binary file (if not the OS default)
+    --clean            Clears the cache directory before packing
+    --yes, --no        Automatically answer yes/no to prompts
+    --default          Automatically accept the default answer to prompts
+    --branch:<branch>  Selects git branch before operation.
 
   Global Options:
     -h, --help     Display help for nasher or one of its commands

--- a/src/nasher/pack.nim
+++ b/src/nasher/pack.nim
@@ -21,9 +21,10 @@ const
     is older than the existing file, the default is to keep the existing file.
 
   Options:
-    --clean        Clears the cache directory before packing
-    --yes, --no    Automatically answer yes/no to prompts
-    --default      Automatically accept the default answer to prompts
+    --clean            Clears the cache directory before packing
+    --yes, --no        Automatically answer yes/no to prompts
+    --default          Automatically accept the default answer to prompts
+    --branch:<branch>  Selects git branch before operation.
 
   Global Options:
     -h, --help     Display help for nasher or one of its commands

--- a/src/nasher/unpack.nim
+++ b/src/nasher/unpack.nim
@@ -1,7 +1,7 @@
 import tables, os, strformat, strutils, times
 from glob import walkGlob
 
-import utils/[cli, manifest, nwn, options, shared]
+import utils/[cli, git, manifest, nwn, options, shared]
 
 const
   helpUnpack* = """
@@ -42,6 +42,7 @@ const
                    output file.
     --yes, --no    Automatically answer yes/no to the overwrite prompt
     --default      Automatically accept the default answer to the overwrite prompt
+    --branch       Place files into specified vcs branch
 
   Global Options:
     -h, --help     Display help for nasher or one of its commands
@@ -114,12 +115,17 @@ proc unpack*(opts: Options, pkg: PackageRef) =
         of "hak": installDir / "hak" / fileName
         of "tlk": installDir / "tlk" / fileName
         else: dir / target.file
+    branch = opts.get("branch", target.branch)
 
   if file == "":
     help(helpUnpack)
 
   if not dirExists(file) and not fileExists(file):
     fatal(fmt"Cannot unpack {file}: file does not exist")
+
+  # If requested, set a specific vcs branch
+  if branch.len > 0:
+    display("VCS Branch", gitSetBranch(dir, branch))
 
   let
     fileType = file.getFileExt

--- a/src/nasher/utils/git.nim
+++ b/src/nasher/utils/git.nim
@@ -60,8 +60,8 @@ proc branch(repo: string, default = ""): string =
     execCmdEx("git rev-parse --abbrev-ref HEAD").output.strip
 
 proc checkout(branch: string, repo: string, create = false, throw = false): bool = 
-  ## Checkout desired branch, if it exists.  If not, prompts for creation or
-  ## uses of current branch.  If can't checkout because of an error, do something else?
+  ## Checkout desired branch, if it exists. If not, prompts for creation or
+  ## uses of current branch. If can't checkout because of an error, do something else?
   var
     flag = ""
     suffix = ""
@@ -75,7 +75,7 @@ proc checkout(branch: string, repo: string, create = false, throw = false): bool
         choiceQuit = "Abort the operation"
         
       let 
-        question = fmt"This operation will create a branch from {repo.branch} instead of master.  What would you like to do?"
+        question = fmt"This operation will create a branch from {repo.branch} instead of master. What would you like to do?"
         choices = [choiceMaster, choiceCurrent, choiceQuit]
 
       case choose(question, choices)
@@ -99,14 +99,13 @@ proc gitSetBranch*(repo = getCurrentDir(), branch: string): string =
   ## Called if the branch option was specified in configuration or command line
   if repo.exists:
     if branch.exists(repo):
-      echo "branch exists"
       if repo.branch == branch:
         result = branch
       else:
         if branch.checkout(repo, throw = true):
           result = repo.branch
         else:
-          fatal(fmt"{branch} could not be checked out.  Resolve all git repo errors before continuing.")
+          fatal(fmt"{branch} could not be checked out. Resolve all git repo errors before continuing.")
     else:
       if repo.empty:
         let question = "Nasher cannot determine the status of this repo because there have not been any commits. " &

--- a/src/nasher/utils/git.nim
+++ b/src/nasher/utils/git.nim
@@ -1,22 +1,7 @@
-import std/[options, os, osproc, strformat, strutils, uri]
+import os, osproc, strformat, strutils, uri
 import cli
 
 from shared import withDir
-
-proc gitExecCmdS(cmd: string): tuple[output: string, exitCode: int] =
-  ## Runs ``cmd``, returning its output on success or ``default`` on error.
-  execCmdEx(cmd)
-  #let (output, errCode) = execCmdEx(cmd)
-  #result = some((output.strip, errCode))
-  #if errcode == 0:
-  #  result = some((output.strip, errCode))
-
-proc gitExecCmd(cmd: string): Option[string] =
-  ## Runs ``cmd``, returning its output on success or ``default`` on error.
- 
-  let (output, errCode) = execCmdEx(cmd)
-  if errcode == 0:
-    result = some(output.strip)
 
 proc gitUser*: string =
   ## Returns the configured git username or "" on failure.
@@ -24,15 +9,19 @@ proc gitUser*: string =
 
   if gitResult.exitCode == 0:
     gitResult.output.strip
-  else: "whatever the default is"
+  else: ""
 
 proc gitEmail*: string =
   ## Returns the configured git email or "" on failure.
-  gitExecCmd("git config --get user.email").get("")
+  let gitResult = execCmdEx("git config --get user.email")
 
-proc gitRemoteS*(repo = getCurrentDir()): string =
+  if gitResult.exitCode == 0:
+    gitResult.output.strip
+  else: ""
+
+proc gitRemote*(repo = getCurrentDir()): string =
   withDir(repo):
-    let url = gitExecCmdS("git ls-remote --get-url")
+    let url = execCmdEx("git ls-remote --get-url")
     result = url.output
 
     if url.exitCode == 0:
@@ -44,20 +33,6 @@ proc gitRemoteS*(repo = getCurrentDir()): string =
         result = ("https://$1/$2$3") % [ssh.hostname, ssh.port, ssh.path]
     else: result = ""
 
-proc gitRemote*(repo = getCurrentDir()): string =
-  ## Returns the remote for the git project in ``dir``. Supports ssh formatted
-  ## remotes.
-  withDir(repo):
-    let url = gitExecCmdS("git ls-remote --get-url")
-
-    result = url.output
-    if result.endsWith(".git"):
-      result.setLen(result.len - 4)
-
-    if result.parseUri.scheme == "":
-      let ssh = parseUri("ssh://" & result)
-      result = ("https://$1/$2$3") % [ssh.hostname, ssh.port, ssh.path]
-
 proc gitInit*(repo = getCurrentDir()): bool =
   ## Initializes dir as a git repository and returns whether the operation was
   ## successful. Will throw an OSError if dir does not exist.
@@ -67,49 +42,68 @@ proc gitInit*(repo = getCurrentDir()): bool =
 proc empty(repo: string): bool =
   ## Check if repo has any commits
   withDir(repo):
-    gitExecCmd("git branch --list").get == ""
+    execCmdEx("git branch --list").output.strip == ""
 
 proc exists(repo: string): bool =
   ## Check for repo existence
   withDir(repo):
-    gitExecCmd("git rev-parse --is-inside-work-tree").isSome
+    execCmdEx("git rev-parse --is-inside-work-tree").output.strip == "true"
 
 proc exists(branch: string, repo: string): bool =
   ## Check for branch existence
   withDir(repo):
-    gitExecCmd(fmt"git show-ref --verify refs/heads/{branch}").isSome
-
-proc checkout(branch: string, repo: string, create = false, throw = false): bool = 
-  ## Checkout desired branch, if it exists.  If not, prompts for creation or
-  ## uses of current branch.  If can't checkout because of an error, do something else?
-  let flag = if create: "-b " else: ""
-  withDir(repo):
-    let gitResult = gitExecCmdS(fmt"git checkout {flag}{branch}")
-    
-    result = gitResult.exitCode == 0
-    if not result and throw:
-      error(gitResult.output)
+    execCmdEx(fmt"git show-ref --verify refs/heads/{branch}").exitCode == 0
   
 proc branch(repo: string, default = ""): string =
   ## Gets the current repo branch
   withDir(repo):
-    let branch = gitExecCmd("git rev-parse --abbrev-ref HEAD")
+    execCmdEx("git rev-parse --abbrev-ref HEAD").output.strip
 
-    if branch.isSome:
-      result = branch.get
+proc checkout(branch: string, repo: string, create = false, throw = false): bool = 
+  ## Checkout desired branch, if it exists.  If not, prompts for creation or
+  ## uses of current branch.  If can't checkout because of an error, do something else?
+  var
+    flag = ""
+    suffix = ""
+  
+  if create:
+    flag = "-b "
+    if repo.branch != "master" and not repo.empty and "master".exists(repo):
+      const
+        choiceMaster = "Create branch from master"
+        choiceCurrent = "Create branch from current branch"
+        choiceQuit = "Abort the operation"
+        
+      let 
+        question = fmt"This operation will create a branch from {repo.branch} instead of master.  What would you like to do?"
+        choices = [choiceMaster, choiceCurrent, choiceQuit]
+
+      case choose(question, choices)
+      of choiceMaster:
+        suffix = " master"
+      of choiceQuit:
+        quit(QuitSuccess)
+
+  withDir(repo):
+    let gitResult = execCmdEx(fmt"git checkout {flag}{branch}{suffix}")
+
+    result = gitResult.exitCode == 0
+    if not result and throw:
+      error(gitResult.output)
 
 proc create(repo: string, branch: string):bool =
   ## Wrapper function for checkout; creates a new git branch in repo
-  branch.checkout(repo, true)
+  branch.checkout(repo, create = true)
 
 proc gitSetBranch*(repo = getCurrentDir(), branch: string): string =
   ## Called if the branch option was specified in configuration or command line
   if repo.exists:
     if branch.exists(repo):
+      echo "branch exists"
       if repo.branch == branch:
         result = branch
       else:
-        if branch.checkout(repo):
+        if branch.checkout(repo, throw = true):
           result = repo.branch
         else:
           fatal(fmt"{branch} could not be checked out.  Resolve all git repo errors before continuing.")
@@ -130,7 +124,7 @@ proc gitSetBranch*(repo = getCurrentDir(), branch: string): string =
       else:
         if repo.create(branch): result = branch
   else:
-    result = "this folder is not a git repository"
+    result = "this folder is not a vcs repository"
 
 proc gitIgnore*(repo = getCurrentDir(), force = false) =
   ## Creates a .gitignore file in ``dir`` if one does not already exist or if

--- a/src/nasher/utils/git.nim
+++ b/src/nasher/utils/git.nim
@@ -1,12 +1,15 @@
-import os, osproc, strutils, uri
+import os, osproc, strformat, strutils, uri
+import cli
 
 from shared import withDir
 
 proc gitExecCmd(cmd: string, default = ""): string =
   ## Runs ``cmd``, returning its output on success or ``default`` on error.
+  ## If default is empty, returns error text.
   let (output, errCode) = execCmdEx(cmd)
   if errCode != 0:
-    default
+    if default.len == 0: output.strip
+    else: default
   else:
     # Remove trailing newline
     output.strip
@@ -19,15 +22,10 @@ proc gitEmail*: string =
   ## Returns the configured git email or "" on failure.
   gitExecCmd("git config --get user.email")
 
-proc gitRepo*(dir = getCurrentDir()): bool =
-  ## Returns whether ``dir`` is a git repo.
-  withDir(dir):
-    gitExecCmd("git rev-parse --is-inside-work-tree") != "true"
-
-proc gitRemote*(dir = getCurrentDir()): string =
+proc gitRemote*(repo = getCurrentDir()): string =
   ## Returns the remote for the git project in ``dir``. Supports ssh formatted
   ## remotes.
-  withDir(dir):
+  withDir(repo):
     result = gitExecCmd("git ls-remote --get-url")
 
     if result != "":
@@ -38,13 +36,80 @@ proc gitRemote*(dir = getCurrentDir()): string =
         let ssh = parseUri("ssh://" & result)
         result = ("https://$1/$2$3") % [ssh.hostname, ssh.port, ssh.path]
 
-proc gitInit*(dir = getCurrentDir()): bool =
+proc gitInit*(repo = getCurrentDir()): bool =
   ## Initializes dir as a git repository and returns whether the operation was
   ## successful. Will throw an OSError if dir does not exist.
-  withDir(dir):
-     execCmdEx("git init").exitCode == 0
+  withDir(repo):
+    execCmdEx("git init").exitCode == 0
 
-proc gitIgnore*(dir = getCurrentDir(), force = false) =
+proc empty(repo: string): bool =
+  # Check if repo has any commits
+  withDir(repo):
+    gitExecCmd("git branch --list", "none").len == 0
+
+proc exists(repo: string): bool =
+  # Check for repo existence
+  withDir(repo):
+    gitExecCmd("git rev-parse --is-inside-work-tree") == "true"
+
+proc exists(branch: string, repo: string): bool =
+  # Check for branch existence
+  withDir(repo):
+    gitExecCmd("git show-ref --verify refs/heads/" & branch, "error") != "error"
+
+proc checkout(branch: string, repo: string, create = false): bool = 
+  # Checkout desired branch, if it exists.  If not, prompts for creation or
+  # uses of current branch.  If can't checkout because of an error, do something else?
+  if create:
+    withDir(repo):
+      gitExecCmd("git checkout -b " & branch, "error") != "error"
+  else:
+    withDir(repo):
+      gitExecCmd("git checkout " & branch, "error") != "error"
+
+proc branch(repo: string, default = ""): string =
+  # Gets the current repo branch
+  withDir(repo):
+    gitExecCmd("git rev-parse --abbrev-ref HEAD", default)
+
+proc create(repo: string, branch: string):bool =
+  # Wrapper function for checkout; creates a new git branch in repo
+  branch.checkout(repo, true)
+
+proc gitSetBranch*(repo = getCurrentDir(), branch: string): string =
+  ## Called if the branch option was specified in configuration or command line
+  if repo.exists:
+    if branch.exists(repo):
+      if repo.branch == branch:
+        result = branch
+      else:
+        if branch.checkout(repo):
+          result = repo.branch
+        else:
+          withDir(repo):
+            error(gitExecCmd("git checkout " & branch))
+
+          fatal(fmt"You must resolve the git repo error before you can continue on branch {branch}")
+    else:
+      if repo.empty:
+        let question = "Nasher cannot determine the status of this repo because there have not been any commits. " &
+                       fmt"Continue the operation on branch {branch}?"
+
+        if askIf(question):
+          if repo.create(branch): 
+            if branch != "master":
+              warning("check repo structure, orphan branch may have been created")
+
+            result = branch
+          else: fatal(fmt"branch {branch} could not be created")
+        else:
+          fatal("operation aborted by user")
+      else:
+        if branch.create(repo): result = branch
+  else:
+    result = "this folder is not a git repository"
+
+proc gitIgnore*(repo = getCurrentDir(), force = false) =
   ## Creates a .gitignore file in ``dir`` if one does not already exist or if
   ## ``force`` is true. Will throw an OSError if ``dir`` does not exist.
   const
@@ -59,5 +124,5 @@ proc gitIgnore*(dir = getCurrentDir(), force = false) =
     # Ignore the nasher directory
     .nasher/
     """
-  if force or not fileExists(dir / file):
-    writeFile(dir / file, text.unindent(4))
+  if force or not fileExists(repo / file):
+    writeFile(repo / file, text.unindent(4))

--- a/src/nasher/utils/nwn.nim
+++ b/src/nasher/utils/nwn.nim
@@ -59,9 +59,8 @@ proc gffToJson(file, bin, args: string, precision: range[1..32] = 4): JsonNode =
 
   result = state.toJson()
   result.postProcessJson()
-  result.truncateFloats()
+  result.truncateFloats(precision)
   input.close()
-
 
 proc gffToNwnt(inFile, outFile: string, precision: range[1..32] = 4) =
   ## Converts ``file`` to nwnt, stripping the module ID if ``file`` is

--- a/src/nasher/utils/nwn.nim
+++ b/src/nasher/utils/nwn.nim
@@ -1,5 +1,8 @@
-import json, os, osproc, strformat, strutils, math
+import json, os, osproc, strformat, strutils, math, streams, tables
 from sequtils import mapIt, toSeq
+
+import neverwinter/gffjson, neverwinter/gff
+from nwnt import toNwnt, gffRootFromNwnt
 
 import cli, options
 
@@ -35,33 +38,72 @@ proc truncateFloats(j: var JsonNode, precision: range[1..32] = 4, bearing: bool 
   else:
     discard
 
+proc postProcessJson(j: JsonNode) =
+  ## Post-process json before emitting: We make sure to re-sort.
+  if j.kind == JObject:
+    for k, v in j.fields: postProcessJson(v)
+    j.fields.sort do (a, b: auto) -> int: cmpIgnoreCase(a[0], b[0])
+  elif j.kind == JArray:
+    for e in j.elems: postProcessJson(e)
+
 proc gffToJson(file, bin, args: string, precision: range[1..32] = 4): JsonNode =
   ## Converts ``file`` to json, stripping the module ID if ``file`` is
   ## module.ifo.
-  let
-    cmd = join([bin, args, "-i", file.escape, "-k json -p"], " ")
-    (output, errCode) = execCmdEx(cmd, Options)
+  let input  = openFileStream(file)
+  var state = input.readGffRoot(false)
 
-  if errCode != 0:
-    fatal(fmt"Could not parse {file}: {output}")
+  if file.extractFilename == "module.ifo" and state.hasField("Mod_ID", GffVoid):
+    state.del("Mod_ID")
+  elif file.splitFile.ext == ".are" and state.hasField("Version", GffDword):
+    state.del("Version")
 
-  result = output.parseJson
+  result = state.toJson()
+  result.postProcessJson()
+  result.truncateFloats()
+  input.close()
 
-  result.truncateFloats(precision)
 
-  if file.extractFilename == "module.ifo" and result.hasKey("Mod_ID"):
-    result.delete("Mod_ID")
-  elif file.splitFile.ext == ".are" and result.hasKey("Version"):
-    result.delete("Version")
+proc gffToNwnt(inFile, outFile: string, precision: range[1..32] = 4) =
+  ## Converts ``file`` to nwnt, stripping the module ID if ``file`` is
+  ## module.ifo.
+  let input  = openFileStream(inFile)
+  let output = openFileStream(outFile, fmWrite)
+  var state = input.readGffRoot(false)
+
+  if inFile.extractFilename == "module.ifo" and state.hasField("Mod_ID", GffVoid):
+    state.del("Mod_ID")
+  elif inFile.splitFile.ext == ".are" and state.hasField("Version", GffDword):
+    state.del("Version")
+
+  output.toNwnt(state, precision)
+  input.close()
+  output.close()
 
 proc convertFile(inFile, outFile, bin, args: string) =
   ## Converts a ``inFile`` to ``outFile``.
-  let
-    cmd = join([bin, args, "-i", inFile.escape, "-o", outFile.escape], " ")
-    (output, errCode) = execCmdEx(cmd, Options)
+  let inFormat = inFile.splitFile.ext
+  case inFormat
+  of ".nwnt":
+    let input  = openFileStream(inFile)
+    let output = openFileStream(outFile, fmWrite)
+    var state = input.gffRootFromNwnt()
+    output.write(state)
+    input.close()
+    output.close()
+  of ".json":
+    let input  = openFileStream(inFile)
+    let output = openFileStream(outFile, fmWrite)
+    var state = input.parseJson(inFile).gffRootFromJson()
+    output.write(state)
+    input.close()
+    output.close()
+  else:
+    let
+      cmd = join([bin, args, "-i", inFile.escape, "-o", outFile.escape], " ")
+      (output, errCode) = execCmdEx(cmd, Options)
 
-  if errCode != 0:
-    fatal(fmt"Could not convert {inFile}: {output}")
+    if errCode != 0:
+      fatal(fmt"Could not convert {inFile}: {output}")
 
 proc gffConvert*(inFile, outFile, bin, args: string, precision: range[1..32] = 4) =
   ## Converts ``inFile`` to ``outFile``
@@ -69,7 +111,7 @@ proc gffConvert*(inFile, outFile, bin, args: string, precision: range[1..32] = 4
     (dir, name, ext) = outFile.splitFile
     fileType = ext.strip(chars = {'.'})
     outFormat = if fileType in GffExtensions: "gff" else: fileType
-    category = if outFormat in ["json", "gff", "tlk"]: "Converting" else: "Copying"
+    category = if outFormat in ["json", "nwnt", "gff", "tlk"]: "Converting" else: "Copying"
 
   info(category, "$1 -> $2" % [inFile.extractFilename, name & ext])
 
@@ -90,6 +132,11 @@ proc gffConvert*(inFile, outFile, bin, args: string, precision: range[1..32] = 4
       else:
         let text = gffToJson(inFile, bin, args, precision).pretty & "\c\L"
         writeFile(outFile, text)
+    of "nwnt":
+      if inFile.splitFile.ext == ".tlk":
+        convertFile(inFile, outFile, bin, args & " -p")
+      else:
+        gffToNwnt(inFile, outFile, precision) #does filewrite in-proc
     of "gff", "tlk":
       convertFile(inFile, outFile, bin, args)
     else:
@@ -103,7 +150,7 @@ proc isValid(version: string): bool =
 
   if decomp.len < 2 or decomp.len > 4:
     return false
-  
+
   for section in decomp:
     try:
       discard section.parseUInt
@@ -112,7 +159,7 @@ proc isValid(version: string): bool =
       return false
 
 proc updateIfo*(dir, bin, args: string, opts: options.Options, target: options.Target) =
-  ## Updates the areas listing in module.ifo, checks for matching .git files,          
+  ## Updates the areas listing in module.ifo, checks for matching .git files,
   ## and sets module name and min version, if specified
   let
     fileGff = dir / "module.ifo"
@@ -154,7 +201,7 @@ proc updateIfo*(dir, bin, args: string, opts: options.Options, target: options.T
 
     ifoJson["Mod_Area_list"]["value"] = %ifoAreas
     success(fmt"area list updated --> {areas.len} area{plurality} listed")
-  
+
   # Module Name Update
   if moduleName.len > 0 and moduleName != ifoJson["Mod_Name"]["value"]["0"].getStr:
     ifoJson["Mod_Name"]["value"]["0"] = %moduleName
@@ -174,7 +221,7 @@ proc updateIfo*(dir, bin, args: string, opts: options.Options, target: options.T
     else:
       error(fmt"requested min game version '{moduleVersion}' is not valid")
       display("Skipping", "setting module min game version")
-    
+
   writeFile(fileJson, $ifoJson)
   convertFile(fileJson, fileGff, bin, args)
   removeFile(fileJson)

--- a/src/nasher/utils/options.nim
+++ b/src/nasher/utils/options.nim
@@ -9,7 +9,7 @@ type
   Options* = StringTableRef
 
   Package = object
-    name*, description*, version*, url*, modName*, modMinGameVersion*: string
+    name*, description*, version*, url*, modName*, modMinGameVersion*, branch*: string
     authors*, includes*, excludes*, filters*, flags*, updated*: seq[string]
     targets*: seq[Target]
     rules*: seq[Rule]
@@ -17,7 +17,7 @@ type
   PackageRef* = ref Package
 
   Target* = object
-    name*, file*, description*, modName*, modMinGameVersion*: string
+    name*, file*, description*, modName*, modMinGameVersion*, branch*: string
     includes*, excludes*, filters*, flags*: seq[string]
     rules*: seq[Rule]
 

--- a/src/nasher/utils/options.nim
+++ b/src/nasher/utils/options.nim
@@ -340,6 +340,8 @@ proc addTarget(pkg: PackageRef, target: var Target) =
       target.flags = pkg.flags
     if target.rules.len == 0:
       target.rules = pkg.rules
+    if target.branch.len == 0:
+      target.branch = pkg.branch
     if target.modName.len == 0:
       target.modName = pkg.modName
     if target.modMinGameVersion.len == 0:
@@ -385,6 +387,7 @@ proc parsePackageFile(pkg: PackageRef, file: string) =
         of "flags": pkg.flags.add(e.value)
         of "modName": pkg.modName = e.value
         of "modMinGameVersion": pkg.modMinGameVersion = e.value
+        of "branch": pkg.branch = e.value
         else:
           pkg.rules.add((e.key, e.value))
       of "target":
@@ -398,6 +401,7 @@ proc parsePackageFile(pkg: PackageRef, file: string) =
         of "flags": target.flags.add(e.value)
         of "modName": target.modName = e.value
         of "modMinGameVersion": target.modMinGameVersion = e.value
+        of "branch": target.branch = e.value
         else:
           target.rules.add((e.key, e.value))
       of "rules":

--- a/src/nasher/utils/shared.nim
+++ b/src/nasher/utils/shared.nim
@@ -91,7 +91,9 @@ proc expandPath*(path: string, keepUnknownKeys = false): string =
 proc outFile(srcFile: string): string =
   ## Returns the filename of the converted source file
   let (_, name, ext) = srcFile.splitFile
-  if ext == ".json": name else: name & ext
+  if ext == ".json" or ext == ".nwnt": name
+  else: name & ext
+
 
 type
   FileMap* = Table[string, seq[string]]


### PR DESCRIPTION
New branch for git integration, rebased on 0.12.3.  Incorporates requests and suggestions from #50 and addresses #27.

Instead of forcing an initial commit to recognize the repo, nasher will now do what the user is asking and provide a warning if no commits were made in the repo and the branch is not master.

If an existing branch cannot be checked out, nasher will throw a fatal error to prevent overwriting data on the current branch.  The error provided by git will be displayed to the user as part of standard nasher output.  In the sample output below, the first error is the raw git output when a checkout command fails, the second is error text from nasher.
```
      Error: error: Your local changes to the following files would be overwritten by checkout:
         ...    src/aps_onload.nss
         ... Please commit your changes or stash them before you switch branches.
         ... Aborting
      Error: You must resolve the git repo error before you can continue on branch master
```

Lots of formatting changes and new convenience functions in git.  Feel free to wail away on input and I'll get it into the format/function that you want it in.