### PR TITLE
Support Beamdog and GOG installs

### DIFF
--- a/src/nasher.nim
+++ b/src/nasher.nim
@@ -80,32 +80,34 @@ when isMainModule:
        not loadPackageFile(pkg, getPackageFile()):
          fatal("This is not a nasher project. Please run nasher init.")
 
-    case cmd
-    of "config":
-      config(opts)
-    of "init":
-      if init(opts, pkg):
+    withEnv([("NWN_ROOT", getNwnRootDir()),
+             ("NWN_HOME", getNwnHomeDir())]):
+      case cmd
+      of "config":
+        config(opts)
+      of "init":
+        if init(opts, pkg):
+          unpack(opts, pkg)
+      of "unpack":
         unpack(opts, pkg)
-    of "unpack":
-      unpack(opts, pkg)
-    of "list":
-      list(opts, pkg)
-    of "convert", "compile", "pack", "install", "play", "test", "serve":
-      let targets = pkg.getTargets(opts.get("targets"))
-      for target in targets:
-        opts["target"] = target.name
-        if branch == "none":
-          branch = target.branch
-        if branch.len > 0:
-          display("VCS Branch:", gitSetBranch(dir, branch))
+      of "list":
+        list(opts, pkg)
+      of "convert", "compile", "pack", "install", "play", "test", "serve":
+        let targets = pkg.getTargets(opts.get("targets"))
+        for target in targets:
+          opts["target"] = target.name
+          if branch == "none":
+            branch = target.branch
+          if branch.len > 0:
+            display("VCS Branch:", gitSetBranch(dir, branch))
 
-        if convert(opts, pkg) and
-           compile(opts, pkg) and
-           pack(opts, pkg) and
-           install(opts, pkg):
-             launch(opts)
-    else:
-      help(helpAll, QuitFailure)
+          if convert(opts, pkg) and
+             compile(opts, pkg) and
+             pack(opts, pkg) and
+             install(opts, pkg):
+               launch(opts)
+      else:
+        help(helpAll, QuitFailure)
   except NasherError:
     error(getCurrentExceptionMsg())
     quit(QuitFailure)

--- a/src/nasher/install.nim
+++ b/src/nasher/install.nim
@@ -39,7 +39,7 @@ proc install*(opts: Options, pkg: PackageRef): bool =
   let
     cmd = opts["command"]
     file = opts["file"]
-    dir = opts.getOrPut("installDir", getNwnHomeDir()).expandPath
+    dir = opts.getOrPut("installDir", getEnv("NWN_ROOT")).expandPath
 
   if opts.get("noInstall", false):
     return cmd != "install"

--- a/src/nasher/install.nim
+++ b/src/nasher/install.nim
@@ -39,7 +39,7 @@ proc install*(opts: Options, pkg: PackageRef): bool =
   let
     cmd = opts["command"]
     file = opts["file"]
-    dir = opts.getOrPut("installDir", getNwnInstallDir()).expandPath
+    dir = opts.getOrPut("installDir", getNwnHomeDir()).expandPath
 
   if opts.get("noInstall", false):
     return cmd != "install"

--- a/src/nasher/launch.nim
+++ b/src/nasher/launch.nim
@@ -35,25 +35,28 @@ const
     --no-color     Disable color output (automatic if not a tty)
   """
 
-
-const
-  SteamPath = joinPath("Steam", "steamapps", "common", "Neverwinter Nights", "bin")
-
 proc getGameBin: string =
+  let binDir = getNwnRootDir() / "bin"
   when defined(Linux):
-    result = "~/.local/share" / SteamPath / "linux-x86/nwmain-linux"
-  when defined(Windows):
-    result = "${PROGRAMFILES(X86)}" / SteamPath / "win32" / "nwmain.exe"
-  when defined(MacOS):
-    result = "~/Library/Application Support" / SteamPath / "macos/nwmain.app/Contents/MacOS/nwmain"
+    result = binDir / "linux-x86" / "nwmain-linux"
+  elif defined(Windows):
+    result = binDir / "win32" / "nwmain.exe"
+  elif defined(MacOS):
+    result = binDir / "macos" / "nwmain.app" / "Contents" / "MacOS" / "nwmain"
+  else:
+    raise newException(ValueError, "Cannot find nwmain: unsupported OS")
 
 proc getServerBin: string =
+  let binDir = getNwnRootDir() / "bin"
   when defined(Linux):
-    result = "~/.local/share" / SteamPath / "linux-x86/nwserver-linux"
-  when defined(Windows):
+    result = binDir / "linux-x86" / "nwserver-linux"
+  elif defined(Windows):
+    result = binDir / "win32" / "nwserver.exe"
     result = "${PROGRAMFILES(X86)}" / SteamPath / "win32" / "nwmain.exe"
-  when defined(MacOS):
-    result = "~/Library/Application Support" / SteamPath / "macos/nwserver-macos"
+  elif defined(MacOS):
+    result = binDir / "macos" / "nwserver-macos"
+  else:
+    raise newException(ValueError, "Cannot find nwserver: unsupported OS")
 
 proc launch*(opts: Options) =
   let

--- a/src/nasher/launch.nim
+++ b/src/nasher/launch.nim
@@ -36,7 +36,7 @@ const
   """
 
 proc getGameBin: string =
-  let binDir = getNwnRootDir() / "bin"
+  let binDir = getEnv("NWN_ROOT") / "bin"
   when defined(Linux):
     result = binDir / "linux-x86" / "nwmain-linux"
   elif defined(Windows):
@@ -47,7 +47,7 @@ proc getGameBin: string =
     raise newException(ValueError, "Cannot find nwmain: unsupported OS")
 
 proc getServerBin: string =
-  let binDir = getNwnRootDir() / "bin"
+  let binDir = getEnv("NWN_ROOT") / "bin"
   when defined(Linux):
     result = binDir / "linux-x86" / "nwserver-linux"
   elif defined(Windows):

--- a/src/nasher/launch.nim
+++ b/src/nasher/launch.nim
@@ -41,7 +41,7 @@ proc getGameBin: string =
     result = binDir / "linux-x86" / "nwmain-linux"
   elif defined(Windows):
     result = binDir / "win32" / "nwmain.exe"
-  elif defined(MacOS):
+  elif defined(MacOSX):
     result = binDir / "macos" / "nwmain.app" / "Contents" / "MacOS" / "nwmain"
   else:
     raise newException(ValueError, "Cannot find nwmain: unsupported OS")
@@ -52,7 +52,7 @@ proc getServerBin: string =
     result = binDir / "linux-x86" / "nwserver-linux"
   elif defined(Windows):
     result = binDir / "win32" / "nwserver.exe"
-  elif defined(MacOS):
+  elif defined(MacOSX):
     result = binDir / "macos" / "nwserver-macos"
   else:
     raise newException(ValueError, "Cannot find nwserver: unsupported OS")

--- a/src/nasher/launch.nim
+++ b/src/nasher/launch.nim
@@ -52,7 +52,6 @@ proc getServerBin: string =
     result = binDir / "linux-x86" / "nwserver-linux"
   elif defined(Windows):
     result = binDir / "win32" / "nwserver.exe"
-    result = "${PROGRAMFILES(X86)}" / SteamPath / "win32" / "nwmain.exe"
   elif defined(MacOS):
     result = binDir / "macos" / "nwserver-macos"
   else:

--- a/src/nasher/unpack.nim
+++ b/src/nasher/unpack.nim
@@ -103,7 +103,7 @@ proc unpack*(opts: Options, pkg: PackageRef) =
   # If the user has specified a file to unpack, use that. Otherwise, look for
   # the installed target file.
   let
-    installDir = opts.get("installDir", getNwnHomeDir()).expandPath
+    installDir = opts.get("installDir", getEnv("NWN_HOME")).expandPath
     target = pkg.getTarget(opts.get("target"))
     file =
       if opts.hasKey("file"): opts.get("file").expandPath.absolutePath

--- a/src/nasher/unpack.nim
+++ b/src/nasher/unpack.nim
@@ -103,7 +103,7 @@ proc unpack*(opts: Options, pkg: PackageRef) =
   # If the user has specified a file to unpack, use that. Otherwise, look for
   # the installed target file.
   let
-    installDir = opts.get("installDir", getNwnInstallDir()).expandPath
+    installDir = opts.get("installDir", getNwnHomeDir()).expandPath
     target = pkg.getTarget(opts.get("target"))
     file =
       if opts.hasKey("file"): opts.get("file").expandPath.absolutePath

--- a/src/nasher/utils/shared.nim
+++ b/src/nasher/utils/shared.nim
@@ -80,7 +80,7 @@ proc getNwnRootDir*: string =
   const steamPath = "Steam" / "steamapps" / "common" / "Neverwinter Nights"
   when defined(Linux):
     path = getHomeDir() / ".local" / "share" / steamPath
-  elif defined(MacOS):
+  elif defined(MacOSX):
     path = getHomeDir() / "Library" / "Application Support" / steamPath
   elif defined(Windows):
     path = getEnv("PROGRAMFILES(X86)") / steamPath
@@ -99,9 +99,10 @@ proc getNwnRootDir*: string =
   const
     settings = "Beamdog Client" / "settings.json"
     releases = ["00829", "00785"]
+
   when defined(Linux):
     let settingsFile = getConfigDir() / settings
-  elif defined(MacOS):
+  elif defined(MacOSX):
     let settingsFile = getHomeDir() / "Library" / "Application Support" / settings
   elif defined(Windows):
     let settingsFile = getHomeDir() / "AppData" / "Roaming" / settings
@@ -118,7 +119,7 @@ proc getNwnRootDir*: string =
         return folder
 
   # GOG Install
-  when defined(Linux) or defined(MacOS):
+  when defined(Linux) or defined(MacOSX):
     path = getHomeDir() / "GOG Games" / "Neverwinter Nights Enhanced Edition"
   elif defined(Windows):
     path = getEnv("PROGRAMFILES(X86)") / "GOG Galaxy" / "Games" / "Neverwinter Nights Enhanced Edition"

--- a/src/nasher/utils/shared.nim
+++ b/src/nasher/utils/shared.nim
@@ -144,6 +144,28 @@ template withDir*(dir: string, body: untyped): untyped =
   finally:
     setCurrentDir(curDir)
 
+template withEnv*(envs: openarray[(string, string)], body: untyped): untyped =
+  ## Executes ``body`` with all environment variables in ``envs``, then returns
+  ## the environment variables to their previous values.
+  var
+    prevValues: seq[(string, string)]
+    noValues: seq[string]
+  for (name, value) in envs:
+    if existsEnv(name):
+      prevValues.add((name, getEnv(name)))
+    else:
+      noValues.add(name)
+    putEnv(name, value)
+
+  body
+
+  for (name, value) in prevValues:
+    putEnv(name, value)
+  for name in noValues:
+    delEnv(name)
+
+
+
 proc findExe*(exe, baseDir: string): string =
   ## As findExe, but uses baseDir as the current directory.
   withDir(baseDir):


### PR DESCRIPTION
This should allow nasher to work without additional configuration for those who installed NWN using the Beamdog client, GOG, or non-default Steam locations. The preferred way of setting the install location is to set the `$NWN_ROOT` environment variable as this variable is also read by nwnsc and niv's tools. In the case of nwnsc, it allows the user to run with the default `-l` flag instead of having to set `--nssFlags:"-n '/path/to/nwn/data'"`.

Still needs testing on non-Linux OSes and with Beamdog installs.

When merged, will close #40.