### PR TITLE
nwnt req bump to 1.3.0

### DIFF
--- a/nasher.nimble
+++ b/nasher.nimble
@@ -13,4 +13,4 @@ bin           = @["nasher"]
 requires "nim >= 1.4.0"
 requires "neverwinter >= 1.4.1"
 requires "glob >= 0.10.0"
-requires "nwnt >= 1.2.2"
+requires "nwnt >= 1.3.0"


### PR DESCRIPTION
nwnt <1.3 not writing out empty lists means a version bump is absolutely necessary to prevent crashes in dialog. No nasher change though.