### PR TITLE
fix: use user as owner of files generated by nasher instead of root

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -10,7 +10,8 @@ RUN dpkg --add-architecture i386 \
     && apt-get install libc6:i386 libncurses5:i386 libstdc++6:i386 -y \
     && rm -fr /var/lib/apt/lists/* /root/.cache/* /usr/share/doc/* /var/cache/man/*
 ARG NASHER_VERSION="0.15.1"
-RUN adduser nasher --disabled-password --gecos "" --uid 1000
+ARG NASHER_USER_ID=1000
+RUN adduser nasher --disabled-password --gecos "" --uid ${NASHER_USER_ID}
 RUN echo "nasher ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && usermod -aG sudo nasher
 WORKDIR /nasher
 RUN chown -R nasher:nasher /nwn /usr/local/bin/nwnsc /nasher

--- a/dockerfile
+++ b/dockerfile
@@ -9,8 +9,14 @@ RUN dpkg --add-architecture i386 \
     && apt upgrade -y \
     && apt-get install libc6:i386 libncurses5:i386 libstdc++6:i386 -y
 ARG NASHER_VERSION="0.14.2"
-ENV PATH="/root/.nimble/bin:$PATH"
+RUN adduser nasher --disabled-password --gecos "" --uid 1000
+RUN echo "nasher ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && usermod -aG sudo nasher
+WORKDIR /nasher
+RUN chown -R nasher:nasher /nwn /usr/local/bin/nwnsc /nasher
+USER nasher
+ENV PATH="/home/nasher/.nimble/bin:$PATH"
 RUN nimble install nasher@#${NASHER_VERSION} -y
+RUN chmod +x /home/nasher/.nimble/bin/nasher
 RUN nasher config --nssFlags:"-n /nwn/data -o" \
     && nasher config --installDir:"/nasher/install" \
     && nasher config --userName:"nasher"


### PR DESCRIPTION
Currently files generated by nasher in docker are generated as root. So files which are generated by nasher are owned by root:root. This forces users to change the permissions of the files with sudo/root permissions. This is bad practice for CI/CD pipelines where the files should be owned by the user that started the docker container. This change fixes this problem.