### PR TITLE
check for file existence in BD install to prevent json parse error

### DIFF
--- a/src/nasher/utils/shared.nim
+++ b/src/nasher/utils/shared.nim
@@ -113,11 +113,11 @@ proc getNwnRootDir*: string =
     doAssert(data.hasKey("folders"))
     doAssert(data["folders"].kind == JArray)
 
-  for release in releases:
-    for folder in data["folders"].getElems.mapIt(it.getStr / release):
-      if dirExists(folder / "data"):
-        info("Located", "Beamdog installation at " & folder)
-        return folder
+    for release in releases:
+      for folder in data["folders"].getElems.mapIt(it.getStr / release):
+        if dirExists(folder / "data"):
+          info("Located", "Beamdog installation at " & folder)
+          return folder
 
   # GOG Install
   when defined(Linux) or defined(MacOSX):

--- a/src/nasher/utils/shared.nim
+++ b/src/nasher/utils/shared.nim
@@ -108,9 +108,10 @@ proc getNwnRootDir*: string =
     let settingsFile = getHomeDir() / "AppData" / "Roaming" / settings
   else:
     raise newException(ValueError, "Could not locate NWN root: unsupported OS")
-  let data = json.parseFile(settingsFile)
-  doAssert(data.hasKey("folders"))
-  doAssert(data["folders"].kind == JArray)
+  if fileExists(settingsFile):
+    let data = json.parseFile(settingsFile)
+    doAssert(data.hasKey("folders"))
+    doAssert(data["folders"].kind == JArray)
 
   for release in releases:
     for folder in data["folders"].getElems.mapIt(it.getStr / release):


### PR DESCRIPTION
I couldn't run nasher with a GOG install because it was erroring out while checking for a beamdog install.  Turns out it was attempting to parse a file that didn't exist, so it choked.  Added a file check in shared.nim to prevent this error.  Test build worked after that.