### PR TITLE
Make the version of nwserver (nwn data) configurable for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
+ARG NWSERVER_IMAGE=beamdog/nwserver:latest
+ARG NWDATA_PATH=/nwn
+
+# nw data source
+FROM $NWSERVER_IMAGE as nwserver
+
 # nwnsc compiler
 FROM nwneetools/nwnsc:latest as nwnsc
+
 # nim image
 FROM nimlang/nim:latest as nasher
 COPY --from=nwnsc usr/local/bin/nwnsc usr/local/bin/nwnsc
-COPY --from=nwnsc /nwn /nwn
+COPY --from=nwserver $NWDATA_PATH /nwn
 RUN dpkg --add-architecture i386 \
     && apt update \
     && apt upgrade -y \


### PR DESCRIPTION
Our dev team has been experiencing occassional issues when our version of the server mismatches what version of NWN data a nasher image is built with. And because all the images the nasher image is built off of are tagged latest, it's hard to know what version of beamdog/nwserver is distributed with a given nasher image.

To mitigate our difficulties, we fork the nasher Dockerfile and build images to a private image repo. I'd like to bring some changes back to the nasher repo so we don't maintain a separate image and others could benefit.

I'm proposing the changes here in case anyone else shares these difficulties or perhaps the approach suggested here agrees with you. Alongside these changes, ideally there'd be extra steps added to when nasher images are built and pushed to dockerhub. If this is something you'd like to see in a github action, I'd be happy to help set that up as well.

[Similar to nwnx](https://github.com/nwnxee/unified/blob/master/base.Dockerfile), the idea is images would be built with an arg for the nwserver along with it's version:

```bash
docker build . --build-arg NWSERVER_IMAGE=beamdog/nwserver:8193.33 -t nasher:0.16.0-nwserver8193.33
```

With images tags liked they would be above, consumers could be explicit about the nwn data and align their CI pipelines with the version of nwserver running on their servers.

And if that adds too much to releases, people will still be able to build and host custom images without having to fork the repo.