### PR TITLE
Skip packing by default if no changed files are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,7 @@ run it separately unless you want to pack files without installing.
 | `--modMinGameVersion:<version>` | sets the `Mod_MinGameVersion` value in `module.ifo` to `<version>` |
 | `--modDescription:<desc>`       | sets the `Mod_Description` value in `module.ifo` to `<desc>`       |
 | `--abortOnCompileError`         | abort packing if errors encountered during compilation             |
+| `--packUnchanged`               | continue packing a file if there are no changed fiels included     |
 
 #### Examples
 
@@ -1012,6 +1013,7 @@ the module (`.mod`) file.
 | `--modMinGameVersion:<version>` | sets the `Mod_MinGameVersion` value in `module.ifo` to `<version>` |
 | `--modDescription:<desc>`       | sets the `Mod_Description` value in `module.ifo` to `<desc>`       |
 | `--abortOnCompileError`         | abort installation if errors encountered during compilation        |
+| `--packUnchanged`               | continue packing a file if there are no changed fiels included     |
 
 #### Examples
 ```console
@@ -1051,6 +1053,7 @@ command is only valid for module targets.
 | `--modMinGameVersion:<version>` | sets the `Mod_MinGameVersion` value in `module.ifo` to `<version>` |
 | `--modDescription:<desc>`       | sets the `Mod_Description` value in `module.ifo` to `<desc>`       |
 | `--abortOnCompileError`         | abort launching if errors encountered during compilation           |
+| `--packUnchanged`               | continue packing a file if there are no changed fiels included     |
 | `--gameBin:<path>`              | path to the `nwmain` binary file                                   |
 | `--serverBin:<path>`            | path to the `nwserver` binary file                                 |
 

--- a/src/nasher/pack.nim
+++ b/src/nasher/pack.nim
@@ -52,7 +52,17 @@ proc pack*(opts: Options, target: Target): bool =
 
   display("Packing", fmt"files for target {target.name} into {file}")
 
+  var
+    manifest = parseManifest(target.name)
+
   if fileExists(file):
+    if (manifest.getChangedFiles(cacheDir).len == 0):
+      if opts.get("packUnchanged", false):
+        display("Packing", "no changed files found")
+      else:
+        display("Skipping", "pack: no changed files found")
+        return cmd != "pack"
+
     let
       packTime = file.getLastModificationTime
       timeDiff = getTimeDiff(fileTime, packTime)
@@ -67,9 +77,6 @@ proc pack*(opts: Options, target: Target): bool =
   let
     bin = opts.findBin("erfUtil", "nwn_erf", "erf utility")
     args = opts.get("erfFlags")
-
-  var
-    manifest = newManifest(target.name)
 
   if file.getFileExt == "tlk":
     let fileName = file.extractFilename


### PR DESCRIPTION
Added behavior to skip packing the erf if:
- the target file already exists
- no changed files are found for the target
- the user didn't pass the `--packUnchanged` option

If skipped, will display a `skipped` message.  If the file exists, and there are no changed files, and the user passes the `--packUnchanged` option, an info message will display stating no new files were found before continuing the pack process.
