### PR TITLE
add case warning for converted filename

### DIFF
--- a/src/nasher/utils/shared.nim
+++ b/src/nasher/utils/shared.nim
@@ -352,6 +352,10 @@ proc outFiles*(srcFiles: seq[string]): FileMap =
   ## if there is more than one file in the target's source tree that can be used
   ## to generate the output file.
   for srcFile in srcFiles:
+    let fileName = srcFile.extractFilename
+    if glob.matches(fileName, "*[A-Z]*", ignoreCase = false):
+      warning("Uppercase characters found in filename $1 may cause 'file not found' prompt during unpack" % [fileName])
+
     let outFile = srcFile.outFile.normalizeFilename
     if result.hasKeyOrPut(outFile, @[srcFile]):
       result[outFile].add(srcFile)


### PR DESCRIPTION
This is completely optional and may not fit into your warning structure, so feel free to discard.  I helped out a user that was constantly receiving the `Prompt: lightbrown01m.utp not found in source directory. Should it be re-added? (y/N)` warning and couldn't understand why since the module was packed with the `install` command and unpacked with the `unpack` command, so all files should be included.  Turns out the original filename was `lightBrown01m.utp` and it was modified to lowercase during the file conversion process.  Since there is no methodology for determining whether the original file was uppercase, this prompt kept arising.

Since nasher allows uppercase letters in various filenames, and allows users to determine which one to use, I added a warning for any file with uppercase letters to let the users know they might receive a prompt during the unpack procedure because a specified file has an uppercase letter in it.  Warning looks like this:

![image](https://user-images.githubusercontent.com/56231301/196077964-815c4fd9-55a3-4557-8cc0-586a2483f707.png)

Again, if it doesn't fit your warning structure, or if the warning is too wordy, feel free to change or toss.   I didn't think a full methodology for storing the original filename was necessary or called for, but that's up to you.